### PR TITLE
Fix B&N in store wifi

### DIFF
--- a/patches/1.2.0/services.patch
+++ b/patches/1.2.0/services.patch
@@ -156,7 +156,7 @@ index 4817821..b4f42b9 100644
 +###
 +###   If the shop button is overloaded, don't update the "in store" icon
 +###
-+    iget-object v0, p0, Lcom/android/server/status/StatusBarService;->mContext:Landroid/content/Context;
++    iget-object v0, p0, Lcom/android/server/status/BNGossamerQuickNavbar;->ctx:Landroid/content/Context;
 +    invoke-static {v0}, Lcom/android/server/status/ModUtils;->overrideShopButton(Landroid/content/Context;)Z
 +
 +    move-result v0

--- a/patches/1.2.0/services.patch
+++ b/patches/1.2.0/services.patch
@@ -2224,7 +2224,7 @@ index 0000000..e962cfb
 +    goto :goto_17
 +.end method
 +
-+.method public static overrideShopButton(Landroid/content/Context;)Ljava/lang/Boolean;
++.method public static overrideShopButton(Landroid/content/Context;)Z
 +    .registers 2
 +    .parameter "context"
 +
@@ -2236,25 +2236,17 @@ index 0000000..e962cfb
 +
 +    move-result-object v0
 +
-+    if-eqz v0, :cond_e
++    if-eqz v0, :cond_a
 +
 +    const/4 v0, 0x1
 +
-+    invoke-static {v0}, Ljava/lang/Boolean;->valueOf(Z)Ljava/lang/Boolean;
++    :goto_9
++    return v0
 +
-+    move-result-object v0
-+
-+    :goto_d
-+    return-object v0
-+
-+    :cond_e
++    :cond_a
 +    const/4 v0, 0x0
 +
-+    invoke-static {v0}, Ljava/lang/Boolean;->valueOf(Z)Ljava/lang/Boolean;
-+
-+    move-result-object v0
-+
-+    goto :goto_d
++    goto :goto_9
 +.end method
 +
 +.method public static replaceQuicknavIcon(Landroid/content/Context;Landroid/widget/ImageView;)V

--- a/src/com/android/server/status/ModUtils.java
+++ b/src/com/android/server/status/ModUtils.java
@@ -168,7 +168,7 @@ public class ModUtils {
     }
   }
 
-  public static Boolean overrideShopButton(Context context)
+  public static boolean overrideShopButton(Context context)
   {
     return ( getButtonBitmap(context, "QUICKNAV_SHOP") != null);
   }


### PR DESCRIPTION
Jeff,

B&N instore wifi causes the NST to crash & go into an android restart loop.  Problem was pulling the wrong context in the patch to BNGossamerQuickNavBar.smali and modutils.java had an incorrect function return type (Boolean instead of boolean).  Roll it into NookManager when you get a chance.

Ralph
